### PR TITLE
fix to bundle.sh for when CDPATH is set; minor README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ mode remaines active after the action - the default is to exit the mode on
 action). We also bind `shift+cmd+m` to exit the mode (but hide it from the HUD
 display) so we can toggle music mode on and off with the same key combo.
 
-Next, let's look at a very powerful technique to that combines focus matching
+Next, let's look at a very powerful technique that combines focus matching
 with key relaying to produce global hotkeys that work when specific apps have
 focus.
 

--- a/scripts/bundle-dev.sh
+++ b/scripts/bundle-dev.sh
@@ -14,7 +14,7 @@ abort() { echo "error: $*" >&2; exit 1; }
 # Ensure we're on macOS
 [[ "$(uname)" == "Darwin" ]] || abort "This bundler only runs on macOS."
 
-ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "$0")/.." >/dev/null && pwd)"
 cd "$ROOT_DIR"
 
 # Configurable via env; sensible defaults otherwise

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -14,7 +14,7 @@ abort() { echo "error: $*" >&2; exit 1; }
 # Ensure we're on macOS
 [[ "$(uname)" == "Darwin" ]] || abort "This bundler only runs on macOS."
 
-ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "$0")/.." &> /dev/null && pwd)"
 cd "$ROOT_DIR"
 
 # Configurable via env; sensible defaults otherwise


### PR DESCRIPTION
I have CDPATH=":~" in my bash config,
so the cd command has output sometimes.